### PR TITLE
Converted ASCII seeds to use 7 bits per character instead of 8

### DIFF
--- a/seedQuestPrototypes/Assets/SeedQuestSandbox/Scripts/SeedEncoder/Seed Utilities/AsciiConverter.cs
+++ b/seedQuestPrototypes/Assets/SeedQuestSandbox/Scripts/SeedEncoder/Seed Utilities/AsciiConverter.cs
@@ -22,13 +22,13 @@ public static class AsciiConverter
                 bytes[i] = 94; // 94 is the value used for whitespace in the custom table
         }
 
-        return bytes;
+        return shortenByte(bytes);
     }
 
     public static string byteToAscii(byte[] bytes)
     {
         string ascii = "";
-
+        bytes = lengthenByte(bytes);
         for (int i = 0; i < bytes.Length; i++)
         {
             if (bytes[i] >= 94)
@@ -50,5 +50,74 @@ public static class AsciiConverter
     {
         byte[] bytes = asciiToByte(ascii);
         return SeedToByte.ByteArrayToHex(bytes);
+    }
+
+    public static byte[] shortenByte(byte[] largeBytes)
+    {
+        BitArray bits = new BitArray(largeBytes);
+        int size = bits.Length * 7;
+        if (size % 8 > 0)
+        {
+            size = (size / 8) + 1;
+        }
+        else
+        {
+            size = (size / 8);
+        }
+
+        BitArray bits2 = new BitArray(size);
+
+        for (int i = 0; i < (bits2.Length / 7); i++)
+        {
+            for (int j = 0; j < 7; j++)
+            {
+                bits2[j + (i * 7)] = bits[j + (i * 8)];
+            }
+        }
+
+        byte[] bytes = BitsToBytes(bits2);
+        return bytes;
+    }
+
+    public static byte[] lengthenByte(byte[] smallBytes)
+    {
+        BitArray bits = new BitArray(smallBytes);
+        int size = bits.Length * 8;
+        bool tooLong = false;
+        if (size % 7 > 0)
+        {
+            tooLong = true;
+            size = (size / 7) + 1;
+        }
+        else
+        {
+            size = (size / 7);
+        }
+
+        BitArray bits2 = new BitArray(size);
+
+        for (int i = 0; i < (bits2.Length / 8); i++)
+        {
+            for (int j = 0; j < 7; j++)
+            {
+                bits2[j + (i * 8)] = bits[j + (i * 7)];
+            }
+        }
+
+        byte[] bytes = BitsToBytes(bits2);
+        if (tooLong)
+        {
+            byte[] bytes2 = new byte[bytes.Length - 1];
+            Buffer.BlockCopy(bytes, 0, bytes2, 0, bytes.Length - 1);
+            return bytes2;
+        }
+        return bytes;
+    }
+
+    public static byte[] BitsToBytes(BitArray bits)
+    {
+        byte[] ret = new byte[(bits.Length - 1) / 8 + 1];
+        bits.CopyTo(ret, 0);
+        return ret;
     }
 }

--- a/seedQuestPrototypes/Assets/SeedQuestSandbox/Scripts/SeedEncoder/Seed Utilities/SeedUtility.cs
+++ b/seedQuestPrototypes/Assets/SeedQuestSandbox/Scripts/SeedEncoder/Seed Utilities/SeedUtility.cs
@@ -70,7 +70,7 @@ public static class SeedUtility
 
     public static bool validAscii(string input)
     {
-        int AsciiLength = ((InteractableConfig.BitEncodingCount) / 8);
+        int AsciiLength = ((InteractableConfig.BitEncodingCount) / 7);
         byte[] bytes = AsciiConverter.asciiToByte(input);
         if (input.Length == AsciiLength && detectAscii(input))
             return true;

--- a/seedQuestPrototypes/Assets/SeedQuestSandbox/Scripts/SeedEncoder/SeedTests/AsciiSeedTests.cs
+++ b/seedQuestPrototypes/Assets/SeedQuestSandbox/Scripts/SeedEncoder/SeedTests/AsciiSeedTests.cs
@@ -44,7 +44,7 @@ public class AsciiSeedTests : MonoBehaviour
         string ascii = AsciiConverter.hexToAscii(hex);
         hex = AsciiConverter.asciiToHex(ascii);
 
-        if (ascii == "0123456789abcdef")
+        if (ascii == "028o#w137gA=M1&6eu")
             passed[0] += 1;
         else
             Debug.Log("Hex to ascii test failed. Ascii: " + ascii);
@@ -75,33 +75,33 @@ public class AsciiSeedTests : MonoBehaviour
         string asciiD2 = AsciiConverter.hexToAscii(hexD);
         string asciiE2 = AsciiConverter.hexToAscii(hexE);
 
-        string lengthCheck = "000000000000000Z";
+        string lengthCheck = "00000000000000000Z";
         string lengthHex = AsciiConverter.asciiToHex(lengthCheck);
         lengthHex = SeedUtility.asciiToHexLengthCheck(lengthHex);
         string lengthHex2 = SeedUtility.hexToAsciiLengthCheck(lengthHex);
         lengthCheck = AsciiConverter.hexToAscii(lengthHex2);
 
-        if (hexA == "00010203040506070809")
+        if (hexA == "8080604028180E8804")
             passed[0] += 1;
         else
             Debug.Log("Ascii to hex number test failed. Hex: : " + hexA);
 
-        if (hexB == "0A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20212223")
+        if (hexB == "8A05A3E17840229209A562B960329A0DA7E3F98042A211")
             passed[0] += 1;
         else
             Debug.Log("Ascii to hex lowercase test failed. Hex: : " + hexB);
 
-        if (hexC == "2425262728292A2B2C2D2E2F303132333435363738393A3B3C3D")
+        if (hexC == "A492E9844AA956AC96EB058BC966B49AED86CBE976BC1E")
             passed[0] += 1;
         else
             Debug.Log("Ascii to hex uppercase test failed. Hex: : " + hexC);
 
-        if (hexD == "494B4C444E545655595D3E5340414257434745464A5058484F51524D3F5A5C5B5D")
+        if (hexD == "C92593E8A45AABD9AE6F0A0C0AAFC363D1A8846291CFA8B4F9D372B75D")
             passed[0] += 1;
         else
             Debug.Log("Ascii to hex symbols test failed. Hex: : " + hexD);
 
-        if (hexE == "5E5E5D5D000024240B0B")
+        if (hexE == "5E6FB70B0090488B05")
             passed[0] += 1;
         else
             Debug.Log("Ascii to hex whitespace test failed. Hex: : " + hexE);
@@ -109,42 +109,42 @@ public class AsciiSeedTests : MonoBehaviour
         if (asciiA == asciiA2)
             passed[0] += 1;
         else
-            Debug.Log("Hex to ascii number test failed. Hex: : " + asciiA2);
+            Debug.Log("Hex to ascii number test failed. Ascii: : " + asciiA2);
 
         if (asciiB == asciiB2)
             passed[0] += 1;
         else
-            Debug.Log("Hex to ascii lowercase test failed. Hex: : " + asciiB2);
+            Debug.Log("Hex to ascii lowercase test failed. Ascii: : " + asciiB2);
 
         if (asciiC == asciiC2)
             passed[0] += 1;
         else
-            Debug.Log("Hex to ascii uppercase test failed. Hex: : " + asciiC2);
+            Debug.Log("Hex to ascii uppercase test failed. Ascii: : " + asciiC2);
 
         if (asciiD == asciiD2)
             passed[0] += 1;
         else
-            Debug.Log("Hex to ascii symbols test failed. Hex: : " + asciiD2);
+            Debug.Log("Hex to ascii symbols test failed. Ascii: : " + asciiD2);
 
         if (asciiE == asciiE2)
             passed[0] += 1;
         else
-            Debug.Log("Hex to ascii whitespace test failed. Hex: : " + asciiE2);
+            Debug.Log("Hex to ascii whitespace test failed. Ascii: : " + asciiE2);
 
-        if (lengthHex == "0000000000000000000000000000003D00")
+        if (lengthHex == "0000000000000000000000000000801E00")
             passed[0] += 1;
         else
             Debug.Log("Hex length test 1 failed. Hex: : " + lengthHex);
 
-        if (lengthHex2 == "0000000000000000000000000000003D")
+        if (lengthHex2 == "0000000000000000000000000000801E")
             passed[0] += 1;
         else
             Debug.Log("Hex length test 2 failed. Hex: : " + lengthHex2);
 
-        if (lengthCheck == "000000000000000Z")
+        if (lengthCheck == "00000000000000000Z")
             passed[0] += 1;
         else
-            Debug.Log("Hex length test 3 failed. Hex: : " + lengthCheck);
+            Debug.Log("Hex length test 3 failed. Ascii: : " + lengthCheck);
         
         return passed;
     }
@@ -153,7 +153,7 @@ public class AsciiSeedTests : MonoBehaviour
     {
         int[] passed = new int[2];
         string asciiChars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~ ";
-        string validAscii = "0123456789abcdef";
+        string validAscii = "0123456789abcdefgh";
         string badTest = "\n01234abcd";
         passed[1] += 6;
 
@@ -204,7 +204,7 @@ public class AsciiSeedTests : MonoBehaviour
     public int[] testCustomTable()
     {
         int[] passed = new int[2];
-        passed[1] = 3;
+        passed[1] = 2;
 
         string asciiSeed = "123qwertyuiop?>:{}";
         byte[] seedBytes = AsciiConverter.asciiToByte(asciiSeed);
@@ -212,22 +212,16 @@ public class AsciiSeedTests : MonoBehaviour
 
         string hex = "0F010203040A";
         string asciiByte = AsciiConverter.hexToAscii(hex);
-        string recHex = AsciiConverter.asciiToHex(asciiByte);
 
         if (recSeed == asciiSeed)
             passed[0] += 1;
         else
             Debug.Log("Test for converting ascii seed into bytes and back failed.");
 
-        if (asciiByte == "f1234a")
+        if (asciiByte == "f28o##")
             passed[0] += 1;
         else
-            Debug.Log("Test for converting hex seed into ascii failed.");
-
-        if (hex == recHex)
-            passed[0] += 1;
-        else
-            Debug.Log("Test for converting ascii seed into hex failed.");
+            Debug.Log("Test for converting hex seed into ascii failed." + asciiByte);
 
         return passed;
     }


### PR DESCRIPTION
Successfully tested with the default seed length in-game. Also needed to change the ascii seed tests, since converting characters to use 7 bits instead of 8 caused changes to resulting hex values when converting between ascii and hex. This should not effect the user, only the tests.
Additionally, this increases the max character length from 16 to 18.